### PR TITLE
Include old_owner for transfers in StreamEvent

### DIFF
--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -585,7 +585,7 @@ mod stream {
       block_hash: BlockHash,
     ) -> Self {
       StreamEvent {
-        version: "4.0.2".to_owned(), // should match the ord-kafka docker image version
+        version: "4.0.0".to_owned(), // should match the ord-kafka docker image version
         inscription_id,
         block_timestamp,
         block_height,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -571,6 +571,7 @@ mod stream {
 
     // transfer fields
     old_location: Option<SatPoint>,
+    old_owner: Option<Address>,
   }
 
   impl StreamEvent {
@@ -622,6 +623,7 @@ mod stream {
         brc20: None,
         domain: None,
         old_location: None,
+        old_owner: None,
         sat_details: None,
       }
     }
@@ -682,6 +684,21 @@ mod stream {
         .unwrap_or_else(|_| panic!("Inscription should exist: {}", self.inscription_id))
       {
         self.enrich_content(inscription);
+        let old_owner: Option<Address> = index
+          .get_transaction(old_satpoint.outpoint.txid)
+          .unwrap_or(None)
+          .and_then(|tx| {
+            Address::from_script(
+              &tx
+                .output
+                .get(old_satpoint.outpoint.vout as usize)
+                .unwrap_or(&TxOut::default())
+                .script_pubkey,
+              StreamEvent::get_network(),
+            )
+            .ok()
+          });
+        self.old_owner = old_owner;
       };
       self
     }


### PR DESCRIPTION
- Fetch old owner of transferred inscription using `old_satpoint`
- makes 1 extra RPC call per transfer, but can save work on the consumer side