### PR TITLE
exclude sat range end from calculating block based rarities

### DIFF
--- a/src/block_rarity.rs
+++ b/src/block_rarity.rs
@@ -2,7 +2,7 @@ use super::*;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum BlockRarity {
   Vintage,
   Nakamoto,

--- a/src/index/updater/inscription_updater/stream.rs
+++ b/src/index/updater/inscription_updater/stream.rs
@@ -1,4 +1,3 @@
-
 use crate::inscription::TransactionInscription;
 use crate::subcommand::traits::Output;
 use base64::{engine::general_purpose, Engine as _};

--- a/src/subcommand/server/rpc.rs
+++ b/src/subcommand/server/rpc.rs
@@ -102,7 +102,7 @@ async fn get_sat_ranges(value: JsonRpcExtractor, index: Arc<Index>) -> JrpcResul
         List::Spent => {}
         List::Unspent(ranges) => {
           for range in ranges {
-            let block_rarities = match get_block_rarities(range.0, range.1) {
+            let block_rarities = match get_block_rarities(range.0, range.1 - 1) {
               Ok(block_rarities) => block_rarities,
               Err(err) => return invalid_params(answer_id, err.to_string()),
             };

--- a/src/subcommand/server/rpc.rs
+++ b/src/subcommand/server/rpc.rs
@@ -13,13 +13,13 @@ use std::cmp::{max, min};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct BlockRarities {
-  pub vintage: u64,
-  pub nakamoto: u64,
-  pub first_transaction: u64,
-  pub pizza: u64,
-  pub block9: u64,
-  pub block78: u64,
-  pub palindrome: u64,
+  pub vintage: Vec<(u64, u64)>,
+  pub nakamoto: Vec<(u64, u64)>,
+  pub first_transaction: Vec<(u64, u64)>,
+  pub pizza: Vec<(u64, u64)>,
+  pub block9: Vec<(u64, u64)>,
+  pub block78: Vec<(u64, u64)>,
+  pub palindrome: Vec<(u64, u64)>,
 }
 
 pub(super) async fn handler(
@@ -102,7 +102,7 @@ async fn get_sat_ranges(value: JsonRpcExtractor, index: Arc<Index>) -> JrpcResul
         List::Spent => {}
         List::Unspent(ranges) => {
           for range in ranges {
-            let block_rarities = match get_block_rarities(range.0, range.1 - 1) {
+            let block_rarities = match get_block_rarities(range.0, range.1) {
               Ok(block_rarities) => block_rarities,
               Err(err) => return invalid_params(answer_id, err.to_string()),
             };
@@ -148,105 +148,74 @@ async fn get_sat_ranges(value: JsonRpcExtractor, index: Arc<Index>) -> JrpcResul
 }
 
 fn get_block_rarities(start: u64, end: u64) -> Result<BlockRarities> {
-  let mut vintage = 0;
-  let mut nakamoto = 0;
-  let mut first_transaction = 0;
-  let mut pizza = 0;
-  let mut block9 = 0;
-  let mut block78 = 0;
+  let mut block78_chunks: Vec<(u64, u64)> = Vec::new();
+  let mut block9_chunks: Vec<(u64, u64)> = Vec::new();
+  let mut first_transaction_chunks: Vec<(u64, u64)> = Vec::new();
+  let mut nakamoto_chunks: Vec<(u64, u64)> = Vec::new();
+  let mut palindrome_chunks: Vec<(u64, u64)> = Vec::new();
+  let mut pizza_chunks: Vec<(u64, u64)> = Vec::new();
+  let mut vintage_chunks: Vec<(u64, u64)> = Vec::new();
 
-  let sat_start = Sat(start);
-  let sat_end = Sat(end);
-
-  if start > end {
-    return Err(anyhow!("invalid sat range: start {start} > end {end}"));
+  if start >= end {
+    return Err(anyhow!("invalid sat range: start {start} >= end {end}"));
   }
-  if sat_start.height().n() != sat_end.height().n() {
+
+  let block_height = Sat(start).height().n();
+
+  if block_height != Sat(end - 1).height().n() {
     return Err(anyhow!(
       "invalid sat range: start {start} and end {end} are in different blocks"
     ));
   }
 
-  let block_height = sat_start.height().n();
-
   // ignore sat ranges later than the max pizza block
   if block_height <= MAX_PIZZA_BLOCK_HEIGHT {
     if block_height <= VINTAGE_BLOCK_HEIGHT {
-      vintage += sat_end.n() - sat_start.n() + 1;
+      vintage_chunks.push((start, end));
     }
 
     if NAKAMOTO_BLOCK_HEIGHTS.contains(&block_height) {
-      nakamoto += sat_end.n() - sat_start.n() + 1;
+      nakamoto_chunks.push((start, end));
     }
 
     if block_height == BLOCK9_BLOCK_HEIGHT {
-      block9 = sat_end.n() - sat_start.n() + 1;
-      if sat_start.n() < FIRST_TRANSACTION_SAT_RANGE.1 {
-        first_transaction = min(FIRST_TRANSACTION_SAT_RANGE.1 - 1, sat_end.n())
-          - max(FIRST_TRANSACTION_SAT_RANGE.0, sat_start.n())
-          + 1;
+      block9_chunks.push((start, end));
+      if start < FIRST_TRANSACTION_SAT_RANGE.1 {
+        first_transaction_chunks.push((start, min(FIRST_TRANSACTION_SAT_RANGE.1, end)));
       }
     } else if block_height == BLOCK78_BLOCK_HEIGHT {
-      block78 = sat_end.n() - sat_start.n() + 1;
+      block78_chunks.push((start, end));
     }
 
     if PIZZA_RANGE_MAP.contains_key(&block_height) {
       let pizza_sat_ranges = PIZZA_RANGE_MAP.get(&block_height).unwrap();
-      pizza += count_pizza_sats_in_range(start, end, pizza_sat_ranges);
+      for range in pizza_sat_ranges {
+        if (start >= range.1) || (end <= range.0) {
+          continue;
+        }
+        pizza_chunks.push((max(range.0, start), min(range.1, end)));
+      }
     }
   }
 
   // Assume sat ranges are not too large for most of the cases.
-  let palindrome = if sat_end.n() - sat_start.n() < 1_000_000 {
-    count_palindrome_sats(sat_start.n(), sat_end.n())
-  } else {
-    // this is a rough estimate, but the result is mostly 0 because the palindrome becomes more sparse as the sat number increases.
-    estimate_palindrome_sats(start, end)
-  };
+  if end - start <= 2_000_000 {
+    for i in start..end {
+      if is_palindrome(&i) {
+        palindrome_chunks.push((i, i + 1));
+      }
+    }
+  }
 
   Ok(BlockRarities {
-    vintage,
-    nakamoto,
-    first_transaction,
-    pizza,
-    block9,
-    block78,
-    palindrome,
+    vintage: vintage_chunks,
+    nakamoto: nakamoto_chunks,
+    first_transaction: first_transaction_chunks,
+    pizza: pizza_chunks,
+    block9: block9_chunks,
+    block78: block78_chunks,
+    palindrome: palindrome_chunks,
   })
-}
-
-fn count_palindrome_sats(start: u64, end: u64) -> u64 {
-  let mut count = 0;
-  for i in start..=end {
-    if is_palindrome(&i) {
-      count += 1;
-    }
-  }
-  count
-}
-
-fn estimate_palindrome_sats(start: u64, end: u64) -> u64 {
-  approximate_palindrome_count(end) - approximate_palindrome_count(start)
-}
-
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-fn approximate_palindrome_count(range: u64) -> u64 {
-  let num_digits = (range as f64).log10().ceil() as u32;
-  let half_digits = num_digits / 2;
-  let multiplier = 1.0 + (range as f64) / (10u64.pow(num_digits + (num_digits + 1) % 2 - 1) as f64);
-
-  (multiplier * (10u64.pow(half_digits) as f64)) as u64
-}
-
-fn count_pizza_sats_in_range(start: u64, end: u64, ranges: &Vec<(u64, u64)>) -> u64 {
-  let mut count = 0;
-  for range in ranges {
-    if (start >= range.1) || (end < range.0) {
-      continue;
-    }
-    count += min(range.1 - 1, end) - max(range.0, start) + 1
-  }
-  count
 }
 
 #[cfg(test)]
@@ -275,87 +244,82 @@ mod tests {
   }
 
   #[test]
-  fn test_estimate_palindrome_sats() {
-    assert_eq!(estimate_palindrome_sats(0, 1), 1);
-    assert_eq!(estimate_palindrome_sats(0, 10), 10);
-    assert_eq!(estimate_palindrome_sats(0, 100), 19);
-    assert_eq!(estimate_palindrome_sats(0, 1_000), 109);
-    assert_eq!(estimate_palindrome_sats(0, 10_000), 199);
-    assert_eq!(estimate_palindrome_sats(0, 100_000), 1099);
-    assert_eq!(estimate_palindrome_sats(0, 1_000_000), 1999);
-    assert_eq!(estimate_palindrome_sats(0, 10_000_000), 10999);
-    assert_eq!(estimate_palindrome_sats(0, 100_000_000), 19999);
-    assert_eq!(estimate_palindrome_sats(0, 1_000_000_000), 109999);
-    assert_eq!(estimate_palindrome_sats(0, 5_000_000_000), 149999);
-
-    assert_eq!(count_palindrome_sats(0, 1), 2);
-    assert_eq!(count_palindrome_sats(0, 10), 10);
-    assert_eq!(count_palindrome_sats(0, 100), 19);
-    assert_eq!(count_palindrome_sats(0, 1_000), 109);
-    assert_eq!(count_palindrome_sats(0, 10_000), 199);
-    assert_eq!(count_palindrome_sats(0, 100_000), 1099);
-    assert_eq!(count_palindrome_sats(0, 1_000_000), 1999);
-
-    assert_eq!(
-      estimate_palindrome_sats(1_000 * COIN_VALUE, 1_000 * COIN_VALUE + 878_364),
-      0
-    );
-    assert_eq!(
-      count_palindrome_sats(1_000 * COIN_VALUE, 1_000 * COIN_VALUE + 878_364),
-      1
-    );
-
-    assert_eq!(
-      estimate_palindrome_sats(20_000_000 * COIN_VALUE, 20_000_000 * COIN_VALUE + 478_364),
-      0
-    );
-    assert_eq!(
-      count_palindrome_sats(20_000_000 * COIN_VALUE, 20_000_000 * COIN_VALUE + 478_364),
-      1
-    );
-  }
-
-  #[test]
   fn test_get_block_rarities() {
     let mut block_rarities =
       get_block_rarities(460 * COIN_VALUE - 10_000, 460 * COIN_VALUE + 10_000).unwrap();
-    assert_eq!(block_rarities.vintage, 20_001);
-    assert_eq!(block_rarities.nakamoto, 20_001);
-    assert_eq!(block_rarities.first_transaction, 10_000);
-    assert_eq!(block_rarities.block9, 20_001);
-    assert_eq!(block_rarities.block78, 0);
-    assert_eq!(block_rarities.pizza, 0);
-    assert_eq!(block_rarities.palindrome, 2);
+    assert_eq!(
+      block_rarities.vintage,
+      vec![(460 * COIN_VALUE - 10_000, 460 * COIN_VALUE + 10_000)]
+    );
+    assert_eq!(
+      block_rarities.nakamoto,
+      vec![(460 * COIN_VALUE - 10_000, 460 * COIN_VALUE + 10_000)]
+    );
+    assert_eq!(
+      block_rarities.first_transaction,
+      vec![(460 * COIN_VALUE - 10_000, 460 * COIN_VALUE)]
+    );
+    assert_eq!(
+      block_rarities.block9,
+      vec![(460 * COIN_VALUE - 10_000, 460 * COIN_VALUE + 10_000)]
+    );
+    assert_eq!(block_rarities.block78, vec![]);
+    assert_eq!(block_rarities.pizza, vec![]);
+    assert_eq!(
+      block_rarities.palindrome,
+      vec![
+        (45_999_999_954, 45_999_999_955),
+        (46_000_000_064, 46_000_000_065)
+      ]
+    );
 
     block_rarities =
       get_block_rarities(78 * 50 * COIN_VALUE + 10_000, 78 * 50 * COIN_VALUE + 20_000).unwrap();
-    assert_eq!(block_rarities.vintage, 10_001);
-    assert_eq!(block_rarities.nakamoto, 0);
-    assert_eq!(block_rarities.first_transaction, 0);
-    assert_eq!(block_rarities.block9, 0);
-    assert_eq!(block_rarities.block78, 10_001);
-    assert_eq!(block_rarities.pizza, 0);
-    assert_eq!(block_rarities.palindrome, 0);
+    assert_eq!(
+      block_rarities.vintage,
+      vec![(78 * 50 * COIN_VALUE + 10_000, 78 * 50 * COIN_VALUE + 20_000)]
+    );
+    assert_eq!(block_rarities.nakamoto, vec![]);
+    assert_eq!(block_rarities.first_transaction, vec![]);
+    assert_eq!(block_rarities.block9, vec![]);
+    assert_eq!(
+      block_rarities.block78,
+      vec![(78 * 50 * COIN_VALUE + 10_000, 78 * 50 * COIN_VALUE + 20_000)]
+    );
+    assert_eq!(block_rarities.pizza, vec![]);
+    assert_eq!(block_rarities.palindrome, vec![]);
 
     block_rarities = get_block_rarities(
       286 * 50 * COIN_VALUE + 10_000,
       286 * 50 * COIN_VALUE + 20_000,
     )
     .unwrap();
-    assert_eq!(block_rarities.vintage, 10_001);
-    assert_eq!(block_rarities.nakamoto, 10_001);
-    assert_eq!(block_rarities.first_transaction, 0);
-    assert_eq!(block_rarities.block9, 0);
-    assert_eq!(block_rarities.block78, 0);
-    assert_eq!(block_rarities.pizza, 0);
-    assert_eq!(block_rarities.palindrome, 0);
+    assert_eq!(
+      block_rarities.vintage,
+      vec![(
+        286 * 50 * COIN_VALUE + 10_000,
+        286 * 50 * COIN_VALUE + 20_000
+      )]
+    );
+    assert_eq!(
+      block_rarities.nakamoto,
+      vec![(
+        286 * 50 * COIN_VALUE + 10_000,
+        286 * 50 * COIN_VALUE + 20_000
+      )]
+    );
+    assert_eq!(block_rarities.first_transaction, vec![]);
+    assert_eq!(block_rarities.block9, vec![]);
+    assert_eq!(block_rarities.block78, vec![]);
+    assert_eq!(block_rarities.pizza, vec![]);
+    assert_eq!(block_rarities.palindrome, vec![]);
 
     block_rarities = get_block_rarities(204589006000000, 204589046000000).unwrap();
-    assert_eq!(block_rarities.vintage, 0);
-    assert_eq!(block_rarities.nakamoto, 0);
-    assert_eq!(block_rarities.first_transaction, 0);
-    assert_eq!(block_rarities.block9, 0);
-    assert_eq!(block_rarities.block78, 0);
+    assert_eq!(block_rarities.vintage, vec![]);
+    assert_eq!(block_rarities.nakamoto, vec![]);
+    assert_eq!(block_rarities.first_transaction, vec![]);
+    assert_eq!(block_rarities.block9, vec![]);
+    assert_eq!(block_rarities.block78, vec![]);
     /* qualified range
     204589006000000	,	204589008000000 -> 2_000_000
     204589017000000	,	204589019000000 -> 2_000_000
@@ -367,7 +331,20 @@ mod tests {
     204589041000000	,	204589043000000 -> 2_000_000
     204589045000000	,	204589046000000 -> 1_000_000
     */
-    assert_eq!(block_rarities.pizza, 13_000_000);
-    assert_eq!(block_rarities.palindrome, 4);
+    assert_eq!(
+      block_rarities.pizza,
+      vec![
+        (204589006000000, 204589008000000),
+        (204589017000000, 204589019000000),
+        (204589026000000, 204589028000000),
+        (204589029000000, 204589030000000),
+        (204589032000000, 204589033000000),
+        (204589034000000, 204589035000000),
+        (204589037000000, 204589038000000),
+        (204589041000000, 204589043000000),
+        (204589045000000, 204589046000000)
+      ]
+    );
+    assert_eq!(block_rarities.palindrome, vec![]);
   }
 }


### PR DESCRIPTION
Found the unspent range's end index should be excluded from the sat range.
And return the block rarity chunks within sat ranges, instead of total count.

Below is an example:
POST: /rpc/v1 with payload
```
{
"jsonrpc": "2.0",
"method": "getSatRanges",
"params": { "utxos": ["6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"]},
"id": 0
}
```

The expected response after fix is:
```
{
    "jsonrpc": "2.0",
    "result": {
        "rare_sats": [
            {
                "offset": 0,
                "rarity": "uncommon",
                "sat": 2745000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "549.0",
                    "degree": "0°549′549″0‴",
                    "epoch": 0,
                    "height": 549,
                    "name": "nvfzolywpwr",
                    "number": 2745000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 5000000000,
                "rarity": "uncommon",
                "sat": 385000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "77.0",
                    "degree": "0°77′77″0‴",
                    "epoch": 0,
                    "height": 77,
                    "name": "nvrhkcdwqfx",
                    "number": 385000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 10000000000,
                "rarity": "uncommon",
                "sat": 3270000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "654.0",
                    "degree": "0°654′654″0‴",
                    "epoch": 0,
                    "height": 654,
                    "name": "nvdmezeayyj",
                    "number": 3270000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 15000000000,
                "rarity": "uncommon",
                "sat": 8715000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "1743.0",
                    "degree": "0°1743′1743″0‴",
                    "epoch": 0,
                    "height": 1743,
                    "name": "nudkguxlxdh",
                    "number": 8715000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 20000000000,
                "rarity": "uncommon",
                "sat": 10510000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "2102.0",
                    "degree": "0°2102′86″0‴",
                    "epoch": 0,
                    "height": 2102,
                    "name": "ntuuuedgfiv",
                    "number": 10510000000000,
                    "offset": 0,
                    "period": 1,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 25000000000,
                "rarity": "uncommon",
                "sat": 7755000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "1551.0",
                    "degree": "0°1551′1551″0‴",
                    "epoch": 0,
                    "height": 1551,
                    "name": "nuhzulqgeij",
                    "number": 7755000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 30000000000,
                "rarity": "uncommon",
                "sat": 8580000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "1716.0",
                    "degree": "0°1716′1716″0‴",
                    "epoch": 0,
                    "height": 1716,
                    "name": "nuebbvfuldp",
                    "number": 8580000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 35000000000,
                "rarity": "uncommon",
                "sat": 3495000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "699.0",
                    "degree": "0°699′699″0‴",
                    "epoch": 0,
                    "height": 699,
                    "name": "nvckepyvkgn",
                    "number": 3495000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 40000000000,
                "rarity": "uncommon",
                "sat": 515000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "103.0",
                    "degree": "0°103′103″0‴",
                    "epoch": 0,
                    "height": 103,
                    "name": "nvqrfgraxxx",
                    "number": 515000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "offset": 45000000000,
                "rarity": "uncommon",
                "sat": 5950000000000,
                "sat_details": {
                    "cycle": 0,
                    "decimal": "1190.0",
                    "degree": "0°1190′1190″0‴",
                    "epoch": 0,
                    "height": 1190,
                    "name": "nuqqnmblnnl",
                    "number": 5950000000000,
                    "offset": 0,
                    "period": 0,
                    "rarity": "uncommon"
                },
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            }
        ],
        "sat_ranges": [
            {
                "block_rarities": [
                    {
                        "block_rarity": "vintage",
                        "chunks": [
                            [
                                2745000000000,
                                2750000000000
                            ]
                        ]
                    }
                ],
                "end": 2750000000000,
                "start": 2745000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [
                    {
                        "block_rarity": "vintage",
                        "chunks": [
                            [
                                385000000000,
                                390000000000
                            ]
                        ]
                    }
                ],
                "end": 390000000000,
                "start": 385000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [
                    {
                        "block_rarity": "vintage",
                        "chunks": [
                            [
                                3270000000000,
                                3275000000000
                            ]
                        ]
                    }
                ],
                "end": 3275000000000,
                "start": 3270000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [],
                "end": 8720000000000,
                "start": 8715000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [],
                "end": 10515000000000,
                "start": 10510000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [],
                "end": 7760000000000,
                "start": 7755000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [],
                "end": 8585000000000,
                "start": 8580000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [
                    {
                        "block_rarity": "vintage",
                        "chunks": [
                            [
                                3495000000000,
                                3500000000000
                            ]
                        ]
                    }
                ],
                "end": 3500000000000,
                "start": 3495000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [
                    {
                        "block_rarity": "vintage",
                        "chunks": [
                            [
                                515000000000,
                                520000000000
                            ]
                        ]
                    }
                ],
                "end": 520000000000,
                "start": 515000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "block_rarities": [],
                "end": 5954999999859,
                "start": 5950000000000,
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            }
        ]
    },
    "id": 0
}
```


