### PR TITLE
Refactor rpc response to put rare sats and sat ranges under utxo object

### DIFF
--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -65,19 +65,27 @@ pub(crate) fn rare_sats(
 ) -> Vec<(OutPoint, Sat, u64, Rarity)> {
   utxos
     .into_iter()
-    .flat_map(|(outpoint, sat_ranges)| {
-      let mut offset = 0;
-      sat_ranges.into_iter().filter_map(move |(start, end)| {
-        let sat = Sat(start);
-        let rarity = sat.rarity();
-        let start_offset = offset;
-        offset += end - start;
-        if rarity > Rarity::Common {
-          Some((outpoint, sat, start_offset, rarity))
-        } else {
-          None
-        }
-      })
+    .flat_map(|(outpoint, sat_ranges)| rare_sats_from_outpoint(outpoint, sat_ranges))
+    .collect()
+}
+
+pub(crate) fn rare_sats_from_outpoint(
+  outpoint: OutPoint,
+  sat_ranges: Vec<(u64, u64)>,
+) -> Vec<(OutPoint, Sat, u64, Rarity)> {
+  let mut offset = 0;
+  sat_ranges
+    .into_iter()
+    .filter_map(move |(start, end)| {
+      let sat = Sat(start);
+      let rarity = sat.rarity();
+      let start_offset = offset;
+      offset += end - start;
+      if rarity > Rarity::Common {
+        Some((outpoint, sat, start_offset, rarity))
+      } else {
+        None
+      }
     })
     .collect()
 }


### PR DESCRIPTION
**Rare sats** and **Sat ranges** under the same utxo were returned into two independent arrays, which has duplicated utxo information, and difficult to use since the request is a list of utxos.

Tested on signet with:
Request:
```
{
"jsonrpc": "2.0",
"method": "getSatRanges",
"params": { "utxos": ["6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1","41b6eaeab71162a848bd493151b9011b71be2a43e5e5b99635af02c78b0bd1d7:6"]},
"id": 0
}
```
Response:
```
{
    "jsonrpc": "2.0",
    "result": {
        "utxos": [
            {
                "rare_sats": [
                    {
                        "offset": 0,
                        "rarity": "uncommon",
                        "sat": 2745000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "549.0",
                            "degree": "0°549′549″0‴",
                            "epoch": 0,
                            "height": 549,
                            "name": "nvfzolywpwr",
                            "number": 2745000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 5000000000,
                        "rarity": "uncommon",
                        "sat": 385000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "77.0",
                            "degree": "0°77′77″0‴",
                            "epoch": 0,
                            "height": 77,
                            "name": "nvrhkcdwqfx",
                            "number": 385000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 10000000000,
                        "rarity": "uncommon",
                        "sat": 3270000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "654.0",
                            "degree": "0°654′654″0‴",
                            "epoch": 0,
                            "height": 654,
                            "name": "nvdmezeayyj",
                            "number": 3270000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 15000000000,
                        "rarity": "uncommon",
                        "sat": 8715000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "1743.0",
                            "degree": "0°1743′1743″0‴",
                            "epoch": 0,
                            "height": 1743,
                            "name": "nudkguxlxdh",
                            "number": 8715000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 20000000000,
                        "rarity": "uncommon",
                        "sat": 10510000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "2102.0",
                            "degree": "0°2102′86″0‴",
                            "epoch": 0,
                            "height": 2102,
                            "name": "ntuuuedgfiv",
                            "number": 10510000000000,
                            "offset": 0,
                            "period": 1,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 25000000000,
                        "rarity": "uncommon",
                        "sat": 7755000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "1551.0",
                            "degree": "0°1551′1551″0‴",
                            "epoch": 0,
                            "height": 1551,
                            "name": "nuhzulqgeij",
                            "number": 7755000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 30000000000,
                        "rarity": "uncommon",
                        "sat": 8580000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "1716.0",
                            "degree": "0°1716′1716″0‴",
                            "epoch": 0,
                            "height": 1716,
                            "name": "nuebbvfuldp",
                            "number": 8580000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 35000000000,
                        "rarity": "uncommon",
                        "sat": 3495000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "699.0",
                            "degree": "0°699′699″0‴",
                            "epoch": 0,
                            "height": 699,
                            "name": "nvckepyvkgn",
                            "number": 3495000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 40000000000,
                        "rarity": "uncommon",
                        "sat": 515000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "103.0",
                            "degree": "0°103′103″0‴",
                            "epoch": 0,
                            "height": 103,
                            "name": "nvqrfgraxxx",
                            "number": 515000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 45000000000,
                        "rarity": "uncommon",
                        "sat": 5950000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "1190.0",
                            "degree": "0°1190′1190″0‴",
                            "epoch": 0,
                            "height": 1190,
                            "name": "nuqqnmblnnl",
                            "number": 5950000000000,
                            "offset": 0,
                            "period": 0,
                            "rarity": "uncommon"
                        }
                    }
                ],
                "sat_ranges": [
                    {
                        "block_rarities": [
                            {
                                "block_rarity": "vintage",
                                "chunks": [
                                    [
                                        2745000000000,
                                        2750000000000
                                    ]
                                ]
                            }
                        ],
                        "end": 2750000000000,
                        "start": 2745000000000
                    },
                    {
                        "block_rarities": [
                            {
                                "block_rarity": "vintage",
                                "chunks": [
                                    [
                                        385000000000,
                                        390000000000
                                    ]
                                ]
                            }
                        ],
                        "end": 390000000000,
                        "start": 385000000000
                    },
                    {
                        "block_rarities": [
                            {
                                "block_rarity": "vintage",
                                "chunks": [
                                    [
                                        3270000000000,
                                        3275000000000
                                    ]
                                ]
                            }
                        ],
                        "end": 3275000000000,
                        "start": 3270000000000
                    },
                    {
                        "block_rarities": [],
                        "end": 8720000000000,
                        "start": 8715000000000
                    },
                    {
                        "block_rarities": [],
                        "end": 10515000000000,
                        "start": 10510000000000
                    },
                    {
                        "block_rarities": [],
                        "end": 7760000000000,
                        "start": 7755000000000
                    },
                    {
                        "block_rarities": [],
                        "end": 8585000000000,
                        "start": 8580000000000
                    },
                    {
                        "block_rarities": [
                            {
                                "block_rarity": "vintage",
                                "chunks": [
                                    [
                                        3495000000000,
                                        3500000000000
                                    ]
                                ]
                            }
                        ],
                        "end": 3500000000000,
                        "start": 3495000000000
                    },
                    {
                        "block_rarities": [
                            {
                                "block_rarity": "vintage",
                                "chunks": [
                                    [
                                        515000000000,
                                        520000000000
                                    ]
                                ]
                            }
                        ],
                        "end": 520000000000,
                        "start": 515000000000
                    },
                    {
                        "block_rarities": [],
                        "end": 5954999999859,
                        "start": 5950000000000
                    }
                ],
                "utxo": "6eb09a05147c13f442950028b701e53bf5981feb44e07bc89b0d7b3d4eb9801a:1"
            },
            {
                "rare_sats": [],
                "sat_ranges": [
                    {
                        "block_rarities": [],
                        "end": 41659751231737,
                        "start": 41659751136641
                    }
                ],
                "utxo": "41b6eaeab71162a848bd493151b9011b71be2a43e5e5b99635af02c78b0bd1d7:6"
            }
        ]
    },
    "id": 0
}
```