### PR TITLE
Implement short term palindrome optimization

### DIFF
--- a/src/block_rarity.rs
+++ b/src/block_rarity.rs
@@ -100,6 +100,9 @@ impl<'de> Deserialize<'de> for BlockRarity {
 
 pub(crate) fn is_palindrome(n: &u64) -> bool {
   let s = n.to_string();
+  if s.chars().nth(0) != s.chars().last() {
+    return false;
+  }
   let reversed = s.chars().rev().collect::<String>();
   s == reversed
 }
@@ -126,6 +129,12 @@ fn is_pizza_sat(sat: &Sat) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn test_is_palindrome() {
+    assert!(is_palindrome(&164114646411461u64));
+    assert!(!is_palindrome(&164114646411462u64));
+  }
 
   #[test]
   fn block_rarities() {

--- a/src/subcommand/server/rpc.rs
+++ b/src/subcommand/server/rpc.rs
@@ -220,16 +220,37 @@ fn get_block_rarity_chunks(block_rarity: &BlockRarity, start: u64, end: u64) -> 
       }
     }
     BlockRarity::Palindrome => {
-      if end - start <= 10_000 {
-        for i in start..end {
-          if is_palindrome(&i) {
-            chunks.push((i, i + 1));
-          }
+      if end - start <= 1_000_000 {
+        for palindrome in get_palindromes_from_sat_range(start, end) {
+          chunks.push((palindrome, palindrome + 1))
         }
       }
     }
   }
   chunks
+}
+
+fn get_palindromes_from_sat_range(start: u64, end: u64) -> Vec<u64> {
+  let mut res = vec![];
+  let s = start.to_string();
+  let e = end.to_string();
+  let mut early_exit = false;
+
+  if s.len() == e.len() && s.len() >= 14 {
+    if s.chars().nth(6) != s.chars().nth(s.len() - 7)
+      && e.chars().nth(6) != e.chars().nth(e.len() - 7)
+    {
+      early_exit = true;
+    }
+  }
+  if !early_exit {
+    for i in start..end {
+      if is_palindrome(&i) {
+        res.push(i);
+      }
+    }
+  }
+  res
 }
 
 #[cfg(test)]
@@ -349,5 +370,16 @@ mod tests {
         ]
       },]
     );
+  }
+
+  #[test]
+  fn test_get_palindromes_from_sat_range() {
+    env_logger::init();
+    let mut palindromes = get_palindromes_from_sat_range(3153515_5000000, 3153515_6000000);
+    assert_eq!(palindromes, vec![31535155153513]);
+    palindromes = get_palindromes_from_sat_range(1999999_9999999, 2000000_0999999);
+    assert_eq!(palindromes, vec![20000000000002]);
+    palindromes = get_palindromes_from_sat_range(3153515_6000000, 3153515_9000000);
+    assert_eq!(palindromes.len(), 0);
   }
 }

--- a/src/subcommand/server/rpc.rs
+++ b/src/subcommand/server/rpc.rs
@@ -220,10 +220,8 @@ fn get_block_rarity_chunks(block_rarity: &BlockRarity, start: u64, end: u64) -> 
       }
     }
     BlockRarity::Palindrome => {
-      if end - start <= 1_000_000 {
-        for palindrome in get_palindromes_from_sat_range(start, end) {
-          chunks.push((palindrome, palindrome + 1))
-        }
+      for palindrome in get_palindromes_from_sat_range(start, end) {
+        chunks.push((palindrome, palindrome + 1))
       }
     }
   }
@@ -234,20 +232,23 @@ fn get_palindromes_from_sat_range(start: u64, end: u64) -> Vec<u64> {
   let mut res = vec![];
   let s = start.to_string();
   let e = end.to_string();
-  let mut early_exit = false;
 
-  if s.len() == e.len() && s.len() >= 14 {
-    if s.chars().nth(6) != s.chars().nth(s.len() - 7)
-      && e.chars().nth(6) != e.chars().nth(e.len() - 7)
-    {
-      early_exit = true;
-    }
+  if end - start > 1_000_000 {
+    return res;
   }
-  if !early_exit {
-    for i in start..end {
-      if is_palindrome(&i) {
-        res.push(i);
-      }
+
+  // Below magic numbers are only applicable for <= 1 million sats ranges.
+  // Will change to the long term solution in the future.
+  if s.len() == e.len()
+    && s.len() >= 14
+    && s.chars().nth(6) != s.chars().nth(s.len() - 7)
+    && e.chars().nth(6) != e.chars().nth(e.len() - 7)
+  {
+    return res;
+  }
+  for i in start..end {
+    if is_palindrome(&i) {
+      res.push(i);
     }
   }
   res
@@ -379,7 +380,7 @@ mod tests {
     assert_eq!(palindromes, vec![31535155153513]);
     palindromes = get_palindromes_from_sat_range(1999999_9999999, 2000000_0999999);
     assert_eq!(palindromes, vec![20000000000002]);
-    palindromes = get_palindromes_from_sat_range(3153515_6000000, 3153515_9000000);
+    palindromes = get_palindromes_from_sat_range(3153515_6000000, 3153515_7000000);
     assert_eq!(palindromes.len(), 0);
   }
 }


### PR DESCRIPTION
This change implement short term palindrome optimization:
1. Reduce scanning range threshold to 1 million sats.
2. Skip the calculation under some condition that the specific range doesn't have palindrome.
3. Early exit if the 1st and last digits are not same.