### PR TITLE
Implement black rarities

### DIFF
--- a/src/rarity.rs
+++ b/src/rarity.rs
@@ -26,10 +26,10 @@ impl Display for Rarity {
         Self::Epic => "epic",
         Self::Legendary => "legendary",
         Self::Mythic => "mythic",
-        Self::BlackUncommon => "black-uncommon",
-        Self::BlackRare => "black-rare",
-        Self::BlackEpic => "black-epic",
-        Self::BlackLegendary => "black-legendary",
+        Self::BlackUncommon => "black_uncommon",
+        Self::BlackRare => "black_rare",
+        Self::BlackEpic => "black_epic",
+        Self::BlackLegendary => "black_legendary",
       }
     )
   }
@@ -83,10 +83,10 @@ impl FromStr for Rarity {
       "epic" => Ok(Self::Epic),
       "legendary" => Ok(Self::Legendary),
       "mythic" => Ok(Self::Mythic),
-      "black-uncommon" => Ok(Self::BlackUncommon),
-      "black-rare" => Ok(Self::BlackRare),
-      "black-epic" => Ok(Self::BlackEpic),
-      "black-legendary" => Ok(Self::BlackLegendary),
+      "black_uncommon" => Ok(Self::BlackUncommon),
+      "black_rare" => Ok(Self::BlackRare),
+      "black_epic" => Ok(Self::BlackEpic),
+      "black_legendary" => Ok(Self::BlackLegendary),
       _ => Err(anyhow!("invalid rarity: {s}")),
     }
   }
@@ -172,10 +172,10 @@ mod tests {
     case("epic", Rarity::Epic);
     case("legendary", Rarity::Legendary);
     case("mythic", Rarity::Mythic);
-    case("black-uncommon", Rarity::BlackUncommon);
-    case("black-rare", Rarity::BlackRare);
-    case("black-epic", Rarity::BlackEpic);
-    case("black-legendary", Rarity::BlackLegendary);
+    case("black_uncommon", Rarity::BlackUncommon);
+    case("black_rare", Rarity::BlackRare);
+    case("black_epic", Rarity::BlackEpic);
+    case("black_legendary", Rarity::BlackLegendary);
   }
 
   #[test]

--- a/src/rarity.rs
+++ b/src/rarity.rs
@@ -8,6 +8,10 @@ pub enum Rarity {
   Epic,
   Legendary,
   Mythic,
+  BlackUncommon,
+  BlackRare,
+  BlackEpic,
+  BlackLegendary,
 }
 
 impl Display for Rarity {
@@ -22,6 +26,10 @@ impl Display for Rarity {
         Self::Epic => "epic",
         Self::Legendary => "legendary",
         Self::Mythic => "mythic",
+        Self::BlackUncommon => "black-uncommon",
+        Self::BlackRare => "black-rare",
+        Self::BlackEpic => "black-epic",
+        Self::BlackLegendary => "black-legendary",
       }
     )
   }
@@ -46,6 +54,18 @@ impl From<Sat> for Rarity {
       Self::Rare
     } else if third == 0 {
       Self::Uncommon
+    } else if third == sat.epoch().subsidy() - 1 {
+      if minute == SUBSIDY_HALVING_INTERVAL - 1 {
+        if second == DIFFCHANGE_INTERVAL - 1 {
+          Self::BlackLegendary
+        } else {
+          Self::BlackEpic
+        }
+      } else if second == DIFFCHANGE_INTERVAL - 1 {
+        Self::BlackRare
+      } else {
+        Self::BlackUncommon
+      }
     } else {
       Self::Common
     }
@@ -63,6 +83,10 @@ impl FromStr for Rarity {
       "epic" => Ok(Self::Epic),
       "legendary" => Ok(Self::Legendary),
       "mythic" => Ok(Self::Mythic),
+      "black-uncommon" => Ok(Self::BlackUncommon),
+      "black-rare" => Ok(Self::BlackRare),
+      "black-epic" => Ok(Self::BlackEpic),
+      "black-legendary" => Ok(Self::BlackLegendary),
       _ => Err(anyhow!("invalid rarity: {s}")),
     }
   }
@@ -95,13 +119,13 @@ mod tests {
     assert_eq!(Sat(0).rarity(), Rarity::Mythic);
     assert_eq!(Sat(1).rarity(), Rarity::Common);
 
-    assert_eq!(Sat(50 * COIN_VALUE - 1).rarity(), Rarity::Common);
+    assert_eq!(Sat(50 * COIN_VALUE - 1).rarity(), Rarity::BlackUncommon);
     assert_eq!(Sat(50 * COIN_VALUE).rarity(), Rarity::Uncommon);
     assert_eq!(Sat(50 * COIN_VALUE + 1).rarity(), Rarity::Common);
 
     assert_eq!(
       Sat(50 * COIN_VALUE * DIFFCHANGE_INTERVAL - 1).rarity(),
-      Rarity::Common
+      Rarity::BlackRare
     );
     assert_eq!(
       Sat(50 * COIN_VALUE * DIFFCHANGE_INTERVAL).rarity(),
@@ -114,7 +138,7 @@ mod tests {
 
     assert_eq!(
       Sat(50 * COIN_VALUE * SUBSIDY_HALVING_INTERVAL - 1).rarity(),
-      Rarity::Common
+      Rarity::BlackEpic
     );
     assert_eq!(
       Sat(50 * COIN_VALUE * SUBSIDY_HALVING_INTERVAL).rarity(),
@@ -125,7 +149,7 @@ mod tests {
       Rarity::Common
     );
 
-    assert_eq!(Sat(2067187500000000 - 1).rarity(), Rarity::Common);
+    assert_eq!(Sat(2067187500000000 - 1).rarity(), Rarity::BlackLegendary);
     assert_eq!(Sat(2067187500000000).rarity(), Rarity::Legendary);
     assert_eq!(Sat(2067187500000000 + 1).rarity(), Rarity::Common);
   }
@@ -148,6 +172,10 @@ mod tests {
     case("epic", Rarity::Epic);
     case("legendary", Rarity::Legendary);
     case("mythic", Rarity::Mythic);
+    case("black-uncommon", Rarity::BlackUncommon);
+    case("black-rare", Rarity::BlackRare);
+    case("black-epic", Rarity::BlackEpic);
+    case("black-legendary", Rarity::BlackLegendary);
   }
 
   #[test]

--- a/src/sat.rs
+++ b/src/sat.rs
@@ -611,7 +611,10 @@ mod tests {
   #[test]
   fn is_common() {
     fn case(n: u64) {
-      assert_eq!(Sat(n).is_common(), Sat(n).rarity() == Rarity::Common);
+      assert_eq!(
+        Sat(n).is_common(),
+        Sat(n).rarity() == Rarity::Common || Sat(n).rarity() > Rarity::Mythic
+      );
     }
 
     case(0);

--- a/src/subcommand/wallet/sats.rs
+++ b/src/subcommand/wallet/sats.rs
@@ -74,20 +74,28 @@ pub(crate) fn rare_sats_from_outpoint(
   sat_ranges: Vec<(u64, u64)>,
 ) -> Vec<(OutPoint, Sat, u64, Rarity)> {
   let mut offset = 0;
-  sat_ranges
-    .into_iter()
-    .filter_map(move |(start, end)| {
-      let sat = Sat(start);
-      let rarity = sat.rarity();
-      let start_offset = offset;
-      offset += end - start;
-      if rarity > Rarity::Common {
-        Some((outpoint, sat, start_offset, rarity))
-      } else {
-        None
+  let mut rare_sats = vec![];
+  for (start, end) in sat_ranges {
+    let first_offset = offset;
+    offset += end - start;
+    let last_offset = offset - 1;
+
+    let first_sat = Sat(start);
+    let first_rarity = first_sat.rarity();
+    if first_rarity > Rarity::Common {
+      rare_sats.push((outpoint, first_sat, first_offset, first_rarity));
+    }
+
+    if end - 1 > start {
+      let last_sat = Sat(end - 1);
+      let last_rarity = last_sat.rarity();
+
+      if last_rarity > Rarity::Common {
+        rare_sats.push((outpoint, last_sat, last_offset, last_rarity));
       }
-    })
-    .collect()
+    }
+  }
+  rare_sats
 }
 
 fn sats_from_tsv(
@@ -153,7 +161,7 @@ mod tests {
     assert_eq!(
       rare_sats(vec![(
         outpoint(1),
-        vec![(51 * COIN_VALUE, 100 * COIN_VALUE), (1234, 5678)],
+        vec![(51 * COIN_VALUE, 100 * COIN_VALUE - 2), (1234, 5678)],
       )]),
       Vec::new()
     )
@@ -164,14 +172,33 @@ mod tests {
     assert_eq!(
       rare_sats(vec![(
         outpoint(1),
-        vec![(10, 80), (50 * COIN_VALUE, 100 * COIN_VALUE)],
+        vec![(10, 80), (50 * COIN_VALUE, 100 * COIN_VALUE - 2)],
       )]),
       vec![(outpoint(1), Sat(50 * COIN_VALUE), 70, Rarity::Uncommon)]
     )
   }
 
   #[test]
-  fn identify_two_rare_sats() {
+  fn identify_black_rare_sat() {
+    assert_eq!(
+      rare_sats(vec![(
+        outpoint(1),
+        vec![(
+          50 * COIN_VALUE * DIFFCHANGE_INTERVAL - 1,
+          50 * COIN_VALUE * DIFFCHANGE_INTERVAL
+        )],
+      )]),
+      vec![(
+        outpoint(1),
+        Sat(50 * COIN_VALUE * DIFFCHANGE_INTERVAL - 1),
+        0,
+        Rarity::BlackRare
+      )]
+    )
+  }
+
+  #[test]
+  fn identify_two_rare_sats_one_black_rare_sats() {
     assert_eq!(
       rare_sats(vec![(
         outpoint(1),
@@ -179,7 +206,13 @@ mod tests {
       )]),
       vec![
         (outpoint(1), Sat(0), 0, Rarity::Mythic),
-        (outpoint(1), Sat(1050000000000000), 100, Rarity::Epic)
+        (outpoint(1), Sat(1050000000000000), 100, Rarity::Epic),
+        (
+          outpoint(1),
+          Sat(1149999999999999),
+          100000000000099,
+          Rarity::BlackUncommon
+        )
       ]
     )
   }


### PR DESCRIPTION
This change implements black rarities, and return them with RPC response.

Tested with signet:

POST: rpc/v1
Data: 
```
{
"jsonrpc": "2.0",
"method": "getSatRanges",
"params": { "utxos": [
  "be298714112a28136f8db7b3c40aca49e5a8c2d3a864750d5c0ff28d56c5705c:1"]},
"id": 0
}
```

Response:
```
{
    "jsonrpc": "2.0",
    "result": {
        "utxos": [
            {
                "rare_sats": [
                    {
                        "offset": 53652,
                        "rarity": "black-uncommon",
                        "sat": 805849999999999,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "161169.4999999999",
                            "degree": "0°161169′1905″4999999999‴",
                            "epoch": 0,
                            "height": 161169,
                            "name": "idifaoacgww",
                            "number": 805849999999999,
                            "offset": 4999999999,
                            "period": 79,
                            "rarity": "black-uncommon"
                        }
                    },
                    {
                        "offset": 53653,
                        "rarity": "uncommon",
                        "sat": 805875000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "161175.0",
                            "degree": "0°161175′1911″0‴",
                            "epoch": 0,
                            "height": 161175,
                            "name": "idibxpwqcjh",
                            "number": 805875000000000,
                            "offset": 0,
                            "period": 79,
                            "rarity": "uncommon"
                        }
                    },
                    {
                        "offset": 5000053652,
                        "rarity": "black-uncommon",
                        "sat": 805879999999999,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "161175.4999999999",
                            "degree": "0°161175′1911″4999999999‴",
                            "epoch": 0,
                            "height": 161175,
                            "name": "idibhlbdgra",
                            "number": 805879999999999,
                            "offset": 4999999999,
                            "period": 79,
                            "rarity": "black-uncommon"
                        }
                    },
                    {
                        "offset": 5000067703,
                        "rarity": "uncommon",
                        "sat": 805880000000000,
                        "sat_details": {
                            "cycle": 0,
                            "decimal": "161176.0",
                            "degree": "0°161176′1912″0‴",
                            "epoch": 0,
                            "height": 161176,
                            "name": "idibhlbdgqz",
                            "number": 805880000000000,
                            "offset": 0,
                            "period": 79,
                            "rarity": "uncommon"
                        }
                    }
                ],
                "sat_ranges": [
                    {
                        "block_rarities": [
                            {
                                "block_rarity": "palindrome",
                                "chunks": [
                                    [
                                        805849999948508,
                                        805849999948509
                                    ]
                                ]
                            }
                        ],
                        "end": 805850000000000,
                        "start": 805849999946347
                    },
                    {
                        "block_rarities": [],
                        "end": 805880000000000,
                        "start": 805875000000000
                    },
                    {
                        "block_rarities": [],
                        "end": 186090370516545,
                        "start": 186090370509174
                    },
                    {
                        "block_rarities": [],
                        "end": 193490016622561,
                        "start": 193490016622340
                    },
                    {
                        "block_rarities": [],
                        "end": 193490016612340,
                        "start": 193490016612187
                    },
                    {
                        "block_rarities": [],
                        "end": 16037104144773,
                        "start": 16037104139526
                    },
                    {
                        "block_rarities": [],
                        "end": 16037104128936,
                        "start": 16037104128715
                    },
                    {
                        "block_rarities": [],
                        "end": 16037104126008,
                        "start": 16037104125508
                    },
                    {
                        "block_rarities": [],
                        "end": 193490016622340,
                        "start": 193490016622150
                    },
                    {
                        "block_rarities": [],
                        "end": 193490016622150,
                        "start": 193490016622003
                    },
                    {
                        "block_rarities": [],
                        "end": 805884999932297,
                        "start": 805880000000000
                    }
                ],
                "utxo": "be298714112a28136f8db7b3c40aca49e5a8c2d3a864750d5c0ff28d56c5705c:1"
            }
        ]
    },
    "id": 0
}
```

**Note: this PR didn't change sat::is_common() function, which is used as part of the indexer to track inscriptions. So no need to re-index**
