### PR TITLE
Add datadog tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06985105829f176e9a3f113b1c71cc24e08f600ef0df4e70cd90d144f889e19f"
+dependencies = [
+ "axum",
+ "futures-core",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1605,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -2057,6 +2084,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-datadog"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f4ecf595095d3b641dd2761a0c3d1f175d3d6c28f38e65418d8004ea3255dd"
+dependencies = [
+ "futures-core",
+ "http",
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "reqwest",
+ "rmp",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7594ec0e11d8e33faf03530a4c49af7064ebba81c1480e01be67d90b356508b"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry_api",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "indexmap 1.9.3",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "regex",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,13 +2181,14 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ord"
-version = "0.8.1"
+version = "6.0.12"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "axum-jrpc",
  "axum-server",
+ "axum-tracing-opentelemetry",
  "base64 0.21.2",
  "bech32",
  "bip39",
@@ -2089,13 +2207,15 @@ dependencies = [
  "http",
  "hyper",
  "indicatif",
- "itertools",
+ "itertools 0.11.0",
  "lazy_static",
  "log",
  "mime",
  "mime_guess",
  "miniscript",
  "mp4",
+ "opentelemetry",
+ "opentelemetry-datadog",
  "ord-bitcoincore-rpc",
  "pretty_assertions",
  "pulldown-cmark",
@@ -2147,6 +2267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2311,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pem"
@@ -2623,6 +2758,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "rss"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,6 +3133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3196,6 +3351,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.27",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
 ]
 
 [[package]]
@@ -3424,7 +3589,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3434,6 +3611,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752ddd669b14a08036a89045e4ac4497ff7ce254e11386647751f36d7c7849ea"
+dependencies = [
+ "http",
+ "opentelemetry-http",
+ "opentelemetry_api",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3519,6 +3748,18 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ord"
 description = "◉ Ordinal wallet and block explorer"
-version = "0.8.1"
+version = "6.0.12"
 license = "CC0-1.0"
 edition = "2021"
 autotests = false
@@ -42,7 +42,10 @@ mime = "0.3.16"
 mime_guess = "2.0.4"
 miniscript = "10.0.0"
 mp4 = "0.13.0"
+axum-tracing-opentelemetry = "0.14.1"
 ord-bitcoincore-rpc = "0.17.0"
+opentelemetry = { version = "0.20.0", features = ["rt-tokio"] }
+opentelemetry-datadog = { version = "0.8.0", features = ["reqwest-blocking-client"] }
 redb = "1.0.5"
 regex = "1.6.0"
 rss = "2.0.1"

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -1,3 +1,4 @@
+use opentelemetry::{global, trace::Tracer};
 use {
   self::inscription_updater::InscriptionUpdater,
   super::{fetcher::Fetcher, *},
@@ -89,15 +90,19 @@ impl<'index> Updater<'_> {
 
     let mut uncommitted = 0;
     let mut value_cache = HashMap::new();
+
+    let tracer = global::tracer("updater");
     while let Ok(block) = rx.recv() {
-      self.index_block(
-        self.index,
-        &mut outpoint_sender,
-        &mut value_receiver,
-        &mut wtx,
-        block,
-        &mut value_cache,
-      )?;
+      tracer.in_span("index_block", |_| {
+        self.index_block(
+          self.index,
+          &mut outpoint_sender,
+          &mut value_receiver,
+          &mut wtx,
+          block,
+          &mut value_cache,
+        )
+      })?;
 
       if let Some(progress_bar) = &mut progress_bar {
         progress_bar.inc(1);
@@ -282,7 +287,7 @@ impl<'index> Updater<'_> {
           // There's no try_iter on tokio::sync::mpsc::Receiver like std::sync::mpsc::Receiver.
           // So we just loop until BATCH_SIZE doing try_recv until it returns None.
           let mut outpoints = vec![outpoint];
-          for _ in 0..BATCH_SIZE-1 {
+          for _ in 0..BATCH_SIZE - 1 {
             let Ok(outpoint) = outpoint_receiver.try_recv() else {
               break;
             };
@@ -305,7 +310,10 @@ impl<'index> Updater<'_> {
           };
           // Send all tx output values back in order
           for (i, tx) in txs.iter().flatten().enumerate() {
-            let Ok(_) = value_sender.send(tx.output[usize::try_from(outpoints[i].vout).unwrap()].value).await else {
+            let Ok(_) = value_sender
+              .send(tx.output[usize::try_from(outpoints[i].vout).unwrap()].value)
+              .await
+            else {
               log::error!("Value channel closed unexpectedly");
               return;
             };

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -1,0 +1,69 @@
+use log::{info, warn};
+use opentelemetry::{
+  sdk::trace::{RandomIdGenerator, Sampler},
+  trace::TraceError,
+};
+use opentelemetry_datadog::ApiVersion;
+use std::env;
+
+fn get_trace_sample_rate() -> f64 {
+  let default_sample_rate = 0.1;
+  let rate = env::var("DD_TRACE_SAMPLE_RATE")
+    .unwrap_or("0.1".to_owned())
+    .parse::<f64>()
+    .unwrap_or_else(|e| {
+      warn!(
+        "failed to parse DD_TRACE_SAMPLE_RATE: {}, defaulting to 0.1 sample rate",
+        e
+      );
+      default_sample_rate
+    });
+
+  if (0.0..=1.0).contains(&rate) {
+    rate
+  } else {
+    warn!("DD_TRACE_SAMPLE_RATE must be between 0 and 1, defaulting to 0.1 sample rate");
+    default_sample_rate
+  }
+}
+
+fn get_agent_url() -> String {
+  let port = env::var("DD_TRACE_AGENT_PORT")
+    .unwrap_or("8126".to_string())
+    .parse::<u64>()
+    .unwrap_or_else(|_| {
+      warn!("Failed to parse DD_TRACE_AGENT_PORT, defaulting to 8126");
+      8126
+    });
+  let host = env::var("DD_TRACE_AGENT_HOSTNAME").unwrap_or("localhost".to_owned());
+
+  format!("http://{host}:{port}")
+}
+
+pub(crate) fn init() -> Result<opentelemetry::sdk::trace::Tracer, TraceError> {
+  opentelemetry_datadog::new_pipeline()
+    .with_service_name(env::var("DD_SERVICE").unwrap_or("ord-kafka".to_owned()))
+    .with_api_version(ApiVersion::Version05)
+    .with_agent_endpoint(get_agent_url())
+    .with_trace_config(
+      opentelemetry::sdk::trace::config()
+        .with_sampler({
+          let sample_rate = get_trace_sample_rate();
+          if sample_rate == 0.0 {
+            Sampler::AlwaysOff
+          } else if sample_rate == 1.0 {
+            Sampler::AlwaysOn
+          } else {
+            Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(sample_rate)))
+          }
+        })
+        .with_id_generator(RandomIdGenerator::default()),
+    )
+    .install_simple()
+}
+
+pub(crate) fn close() {
+  info!("Shutting down tracer...");
+  opentelemetry::global::shutdown_tracer_provider();
+  info!("Tracer shutdown complete.");
+}

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -26,7 +26,7 @@ fn hash() {
 #[test]
 fn unrecognized_object() {
   CommandBuilder::new("parse A")
-    .stderr_regex(r#"error: .*: unrecognized object\n.*"#)
+    .stderr_regex(r"error: .*: unrecognized object\n.*")
     .expected_exit_code(2)
     .run_and_extract_stdout();
 }


### PR DESCRIPTION
Export traces for Datadog via opentelemetry

Docker tag `6.0.12-alpha.1`
<img width="1511" alt="Screenshot 2023-10-16 at 11 17 21 PM" src="https://github.com/magicoss/ord-kafka/assets/12561777/4d994064-f039-4bb6-8b55-97636611f3fc">


