### PR TITLE
Stop producing most of BRC20 transfer events to Kafka (only send "transfer" inscription once)

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -84,6 +84,9 @@ define_table! { STATISTIC_TO_COUNT, u64, u64 }
 define_table! { TRANSACTION_ID_TO_RUNE, &TxidValue, u128 }
 define_table! { TRANSACTION_ID_TO_TRANSACTION, &TxidValue, &[u8] }
 define_table! { WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP, u32, u128 }
+// store how many times an inscription has been transferred, it is used to filter out kafka events of BRC-20 transfer inscriptions.
+// Note: instead of re-indexing to have an accurate count, we can start to count any time cuz it is only for optimzing purpose.
+define_table! { INSCRIPTION_TRANSFER_COUNT, InscriptionIdValue, u32 }
 
 #[derive(Copy, Clone)]
 pub(crate) enum Statistic {
@@ -340,6 +343,7 @@ impl Index {
         tx.open_table(SEQUENCE_NUMBER_TO_SATPOINT)?;
         tx.open_table(TRANSACTION_ID_TO_RUNE)?;
         tx.open_table(WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP)?;
+        tx.open_table(INSCRIPTION_TRANSFER_COUNT)?;
 
         {
           let mut outpoint_to_sat_ranges = tx.open_table(OUTPOINT_TO_SAT_RANGES)?;

--- a/src/index/entry.rs
+++ b/src/index/entry.rs
@@ -374,7 +374,7 @@ impl Entry for SatRange {
   fn store(self) -> Self::Value {
     let base = self.0;
     let delta = self.1 - self.0;
-    let n = u128::from(base) | u128::from(delta) << 51;
+    let n = u128::from(base) | (u128::from(delta) << 51);
     n.to_le_bytes()[0..11].try_into().unwrap()
   }
 }

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -400,6 +400,7 @@ impl Updater<'_> {
     let mut sequence_number_to_satpoint = wtx.open_table(SEQUENCE_NUMBER_TO_SATPOINT)?;
     let mut statistic_to_count = wtx.open_table(STATISTIC_TO_COUNT)?;
     let mut transaction_id_to_transaction = wtx.open_table(TRANSACTION_ID_TO_TRANSACTION)?;
+    let mut inscription_transfer_count = wtx.open_table(INSCRIPTION_TRANSFER_COUNT)?;
 
     let mut lost_sats = statistic_to_count
       .get(&Statistic::LostSats.key())?
@@ -459,6 +460,7 @@ impl Updater<'_> {
       value_cache,
       value_receiver,
       block_hash: block.header.block_hash(),
+      inscription_transfer_count: &mut inscription_transfer_count,
     };
 
     if self.index.index_sats {

--- a/src/index/updater/inscription_updater/stream.rs
+++ b/src/index/updater/inscription_updater/stream.rs
@@ -378,15 +378,17 @@ impl StreamEvent {
     self
   }
 
-  pub fn publish(&mut self) -> Result {
+  pub fn publish(&mut self, transfer_count: u32) -> Result {
     if env::var("KAFKA_TOPIC").is_err() {
       return Ok(());
     }
 
-    // skip brc20 sats mint transfer events
+    // when old_owner exists, only publish "transfer" inscriptions once.
     if let Some(brc20) = &self.brc20 {
-      if brc20.op == "mint" && self.old_owner.is_some() {
-        return Ok(());
+      if self.old_owner.is_some() {
+        if brc20.op != "transfer" || transfer_count > 0 {
+          return Ok(());
+        }
       }
     }
 

--- a/src/index/updater/inscription_updater/stream.rs
+++ b/src/index/updater/inscription_updater/stream.rs
@@ -385,10 +385,8 @@ impl StreamEvent {
 
     // when old_owner exists, only publish "transfer" inscriptions once.
     if let Some(brc20) = &self.brc20 {
-      if self.old_owner.is_some() {
-        if brc20.op != "transfer" || transfer_count > 0 {
-          return Ok(());
-        }
+      if self.old_owner.is_some() && (brc20.op != "transfer" || transfer_count > 0) {
+        return Ok(());
       }
     }
 

--- a/src/index/updater/rune_updater.rs
+++ b/src/index/updater/rune_updater.rs
@@ -355,7 +355,7 @@ impl RuneUpdater<'_, '_, '_> {
         u128::MAX
       },
       divisibility: etching.divisibility,
-      id: u128::from(self.height) << 16 | u128::from(index),
+      id: (u128::from(self.height) << 16) | u128::from(index),
       rune,
       spacers: etching.spacers,
       symbol: etching.symbol,

--- a/src/runes/rune_id.rs
+++ b/src/runes/rune_id.rs
@@ -19,7 +19,7 @@ impl TryFrom<u128> for RuneId {
 
 impl From<RuneId> for u128 {
   fn from(id: RuneId) -> Self {
-    u128::from(id.height) << 16 | u128::from(id.index)
+    (u128::from(id.height) << 16) | u128::from(id.index)
   }
 }
 

--- a/src/runes/spaced_rune.rs
+++ b/src/runes/spaced_rune.rs
@@ -45,7 +45,7 @@ impl Display for SpacedRune {
     for (i, c) in rune.chars().enumerate() {
       write!(f, "{c}")?;
 
-      if i < rune.len() - 1 && self.spacers & 1 << i != 0 {
+      if i < (rune.len() - 1) && (self.spacers & (1 << i)) != 0 {
         write!(f, "•")?;
       }
     }

--- a/src/runes/varint.rs
+++ b/src/runes/varint.rs
@@ -71,7 +71,7 @@ mod tests {
     let mut n = 0;
 
     for i in 0..129 {
-      n = n << 1 | (i % 2);
+      n = (n << 1) | (i % 2);
       let encoded = encode(n);
       let (decoded, length) = decode(&encoded);
       assert_eq!(decoded, n);


### PR DESCRIPTION
To reduce the total # of kafka messages, this change:
- Store "transfer_count" for each inscription into REDB (it is more like a persistent cache, so we don't need to reindex from the beginning).
- If the the inscription is a BRC20 "transfer" inscription, and has been transferred once, we will ignore it when sending StreamEvent.