### PR TITLE
[ord-kafka] fix brc20 filter by checking the 'p' filed in content body

### DIFF
--- a/src/index/updater/inscription_updater/stream.rs
+++ b/src/index/updater/inscription_updater/stream.rs
@@ -383,7 +383,7 @@ impl StreamEvent {
       return Ok(());
     }
 
-    // DO NOT send any brc20 events
+    // DO NOT send brc20 transfer events
     if self.old_owner.is_some() && self.brc20.as_ref().map(|brc| brc.p == "brc-20").unwrap_or(false) {
       return Ok(());
     }

--- a/src/index/updater/inscription_updater/stream.rs
+++ b/src/index/updater/inscription_updater/stream.rs
@@ -384,7 +384,13 @@ impl StreamEvent {
     }
 
     // DO NOT send brc20 transfer events
-    if self.old_owner.is_some() && self.brc20.as_ref().map(|brc| brc.p == "brc-20").unwrap_or(false) {
+    if self.old_owner.is_some()
+      && self
+        .brc20
+        .as_ref()
+        .map(|brc| brc.p == "brc-20")
+        .unwrap_or(false)
+    {
       return Ok(());
     }
 

--- a/src/index/updater/inscription_updater/stream.rs
+++ b/src/index/updater/inscription_updater/stream.rs
@@ -383,8 +383,8 @@ impl StreamEvent {
       return Ok(());
     }
 
-    // DO NOT send brc20 transfer events
-    if self.old_owner.is_some() && self.brc20.is_some() {
+    // DO NOT send any brc20 events
+    if self.old_owner.is_some() && self.brc20.as_ref().map(|brc| brc.p == "brc-20").unwrap_or(false) {
       return Ok(());
     }
 


### PR DESCRIPTION
Also check if brc.p == 'brc-20' to determine if inscription is brc20 related.

There are inscriptions whose body is also serialized json but not brc20, e.g. natcats. Those should be published to the stream event kafka