### PR TITLE
Cache brc20 inscriptions to a new table for filtering

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -1883,7 +1883,7 @@ impl Index {
   pub(crate) fn get_metaprotocol(&self, inscription_id: InscriptionId) -> Result<Option<String>> {
     let rtx = self.database.begin_read()?;
     let metaprotocol_table = rtx.open_table(INSCRIPTION_ID_TO_METAPROTOCOL)?;
-    
+
     if let Some(guard) = metaprotocol_table.get(&inscription_id.store())? {
       if let Ok(s) = std::str::from_utf8(guard.value()) {
         return Ok(Some(s.to_string()));
@@ -1893,10 +1893,12 @@ impl Index {
   }
 
   pub(crate) fn is_brc20(&self, inscription_id: InscriptionId) -> Result<bool> {
-    Ok(self
-      .get_metaprotocol(inscription_id)?
-      .map(|p| p == "brc-20")
-      .unwrap_or(false))
+    Ok(
+      self
+        .get_metaprotocol(inscription_id)?
+        .map(|p| p == "brc-20")
+        .unwrap_or(false),
+    )
   }
 
   #[cfg(test)]

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -477,6 +477,7 @@ impl Updater<'_> {
       }
       let mut tx_block_index = 0;
       for (tx_offset, (tx, txid)) in block.txdata.iter().enumerate().skip(1) {
+        let tx_start = Instant::now();
         log::trace!("Indexing transaction {tx_offset}…");
 
         let mut input_sat_ranges = VecDeque::new();
@@ -521,11 +522,20 @@ impl Updater<'_> {
           self.index,
         )?;
 
+        let tx_duration = tx_start.elapsed();
+        log::info!(
+          "Transaction {} (txid: {}) processed in {:?}",
+          tx_offset,
+          txid,
+          tx_duration
+        );
+
         tx_block_index += 1;
         coinbase_inputs.extend(input_sat_ranges);
       }
 
       if let Some((tx, txid)) = block.txdata.first() {
+        let tx_start = Instant::now();
         self.index_transaction_sats(
           tx,
           *txid,
@@ -538,6 +548,12 @@ impl Updater<'_> {
           index_inscriptions,
           self.index,
         )?;
+        let tx_duration = tx_start.elapsed();
+        log::info!(
+          "Coinbase transaction (txid: {}) processed in {:?}",
+          txid,
+          tx_duration
+        );
       }
 
       if !coinbase_inputs.is_empty() {
@@ -573,7 +589,15 @@ impl Updater<'_> {
         .chain(block.txdata.first())
         .enumerate()
       {
+        let tx_start = Instant::now();
         inscription_updater.index_inscriptions(tx, *txid, tx_block_index, None, self.index)?;
+        let tx_duration = tx_start.elapsed();
+        log::info!(
+          "Transaction {} (txid: {}) processed in {:?}",
+          tx_block_index,
+          txid,
+          tx_duration
+        );
       }
     }
 

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -400,6 +400,7 @@ impl Updater<'_> {
     let mut sequence_number_to_satpoint = wtx.open_table(SEQUENCE_NUMBER_TO_SATPOINT)?;
     let mut statistic_to_count = wtx.open_table(STATISTIC_TO_COUNT)?;
     let mut transaction_id_to_transaction = wtx.open_table(TRANSACTION_ID_TO_TRANSACTION)?;
+    let mut inscription_id_to_metaprotocol = wtx.open_table(INSCRIPTION_ID_TO_METAPROTOCOL)?;
 
     let mut lost_sats = statistic_to_count
       .get(&Statistic::LostSats.key())?
@@ -442,6 +443,7 @@ impl Updater<'_> {
       home_inscriptions: &mut home_inscriptions,
       id_to_sequence_number: &mut inscription_id_to_sequence_number,
       index_transactions: self.index.index_transactions,
+      inscription_id_to_metaprotocol: &mut inscription_id_to_metaprotocol,
       inscription_number_to_sequence_number: &mut inscription_number_to_sequence_number,
       lost_sats,
       next_sequence_number,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -53,7 +53,8 @@ pub(super) struct InscriptionUpdater<'a, 'db, 'tx> {
   pub(super) home_inscriptions: &'a mut Table<'db, 'tx, u32, InscriptionIdValue>,
   pub(super) id_to_sequence_number: &'a mut Table<'db, 'tx, InscriptionIdValue, u32>,
   pub(super) index_transactions: bool,
-  pub(super) inscription_id_to_metaprotocol: &'a mut Table<'db, 'tx, InscriptionIdValue, &'static [u8]>,
+  pub(super) inscription_id_to_metaprotocol:
+    &'a mut Table<'db, 'tx, InscriptionIdValue, &'static [u8]>,
   pub(super) inscription_number_to_sequence_number: &'a mut Table<'db, 'tx, i32, u32>,
   pub(super) lost_sats: u64,
   pub(super) next_sequence_number: u32,
@@ -600,16 +601,13 @@ impl InscriptionUpdater<'_, '_, '_> {
         // Parse once and reuse to avoid parsing again in enrich_content
         let parsed_brc20 = if let Some(body) = inscription.body() {
           use crate::index::updater::inscription_updater::stream::StreamEvent;
-          let content_type = inscription
-            .content_type()
-            .map(|ct| ct.to_string());
+          let content_type = inscription.content_type().map(|ct| ct.to_string());
           if StreamEvent::is_text_related(inscription.media(), content_type) {
             if let Ok(brc20) = serde_json::from_slice::<stream::BRC20>(body) {
               // Store the protocol string (e.g., "brc-20") for future filtering
-              self.inscription_id_to_metaprotocol.insert(
-                &inscription_id.store(),
-                brc20.p.as_bytes(),
-              )?;
+              self
+                .inscription_id_to_metaprotocol
+                .insert(&inscription_id.store(), brc20.p.as_bytes())?;
               Some(brc20)
             } else {
               None


### PR DESCRIPTION
1. Only enrich inscription when creating it;
2. Cache brc20 like inscriptions metaprotocol to a REDB table;
3. Add logging for each tx time;
4. Add ut